### PR TITLE
fix multiple posts after fetch bug

### DIFF
--- a/commands/fetch.js
+++ b/commands/fetch.js
@@ -1,3 +1,4 @@
+const e = require("express");
 const RedditImageFetcher = require("reddit-image-fetcher");
 var items = 1;
 var arr;
@@ -18,29 +19,18 @@ module.exports.run = (client, message, args) => {
     items = args[1];
   }
   try {
-    for (let i = 0; i < items; i++) {
-      try {
-        RedditImageFetcher.fetch({
-          type: "custom",
-          subreddit: nameList,
-          total: 1,
-          allowNSFW: false,
+    RedditImageFetcher.fetch({
+      type: "custom",
+      subreddit: nameList,
+      total: items,
+      allowNSFW: false,
+    })
+      .then((result) => {
+          for (let i = 0; i < result.length; i++) {
+            message.channel.send({ files: [result[i].image] });
+          }
         })
-          .then((result) => {
-            console.log(result);
-            try {
-              message.channel.send({ files: [result[0].image] });
-              arr[i] = result[0].subreddit;
-            } catch (e) {
-              return;
-            }
-          });
-      } catch (e) {
-        message.channel.send("Server Crashed");
-        continue;
-      }
-    }
-  } catch (e) {
+  } catch (e){
     message.channel.send("Server Crashed");
   }
 };


### PR DESCRIPTION
Apologies in advance for my IDE formatting.

I was able to reproduce the bug and I believe this is the cause:
Each time the FOR loop runs, there's a chance the reddit API might return the same image URL, so you end up with duplicate posts once in a while.

To fix this, I changed 2 things:
- The "RedditImageFetcher.fetch" now runs only once and requests "total: items" instead of "total: 1". Therefore, there will be no duplicate images returned since it doesn't reset each time.
- Moved the for loop to just iterate though the results of the fetch and post to the channel each time